### PR TITLE
making schema to string to consider optional keys

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -11,7 +11,7 @@ export type FluentBitSchemaType = {
   id: string;
   name?: string;
   command: COMMANDS;
-  optional?: unknown;
+  optional?: Record<string, unknown>;
 } & { [key: string]: unknown };
 export const FLUENTBIT_REGEX = /(?<![#][ ]*)\[[A-Z]{1,}\]/g;
 

--- a/src/schemaToString.ts
+++ b/src/schemaToString.ts
@@ -1,14 +1,21 @@
 import type { FluentBitSchemaType } from './constants';
 
 const NEW_CHAR = '\n' + ' ' + ' ' + ' ' + ' ';
+
+const propToConfigParam = (key: string, value: unknown): string => `${NEW_CHAR}${key}  ${value}`;
+
 export function schemaToString(configValues: FluentBitSchemaType[]) {
   const blocks = configValues.map((values) => {
     // destructuring id to avoid having it in the final output.
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    const { command, id, ...rest } = values;
-    const properties = Object.entries(rest).reduce((memo, [key, value]) => `${memo}${NEW_CHAR}${key}  ${value}`, '');
+    const { command, id, optional, ...rest } = values;
+    const properties = Object.entries({ ...rest, ...optional }).reduce(
+      (memo, [key, value]) => `${memo}${propToConfigParam(key, value)}`,
+      ''
+    );
 
     return [`[${command.toUpperCase()}]`, properties].join('');
   });
+
   return blocks.join('\n\n');
 }


### PR DESCRIPTION
While playing with ast -> schema, I discovered that if for some reason we try to pass a schema with `optional` through the function that makes it back to a string, it will skip optional keys. 

I've made the adjustment so it is included. 