### PR TITLE
exposing token error + pure message

### DIFF
--- a/__tests__/directives.spec.ts
+++ b/__tests__/directives.spec.ts
@@ -21,6 +21,9 @@ describe('Fluent Bit: Directives', () => {
     } catch (e) {
       const error = e as TokenError;
       expect(error.message).toMatchInlineSnapshot(
+        '"You have defined a Directive not supported (@WHATEVER something that we do not have implemented/invalid. ). The supported directives are: SET,INCLUDE"'
+      );
+      expect(error.formattedError).toMatchInlineSnapshot(
         '"/__fixtures__/directives/directives/ephemeral.conf: 3:5 You have defined a Directive not supported (@WHATEVER something that we do not have implemented/invalid. ). The supported directives are: SET,INCLUDE"'
       );
     }
@@ -118,6 +121,9 @@ describe('Fluent Bit: Directives', () => {
         expect(error.line).toBe(3);
         expect(error.col).toBe(1);
         expect(error.message).toMatchInlineSnapshot(
+          '"You are trying to include nested/tail.conf, but we also found more arguments (shouldNotHaveAnytingElse). Includes can only have a single value (ex: @includes path/to/a/file)"'
+        );
+        expect(error.formattedError).toMatchInlineSnapshot(
           '"<PROJECT_ROOT>/__fixtures__/directives/include/withWrongIncludeValue.conf: 3:1 You are trying to include nested/tail.conf, but we also found more arguments (shouldNotHaveAnytingElse). Includes can only have a single value (ex: @includes path/to/a/file)"'
         );
         expect(error.filePath).toMatchInlineSnapshot(
@@ -136,6 +142,9 @@ describe('Fluent Bit: Directives', () => {
         expect(error.line).toBe(9);
         expect(error.col).toBe(1);
         expect(error.message).toMatchInlineSnapshot(
+          '"You are trying to include <PROJECT_ROOT>/__fixtures__/directives/include/nested/tail.conf. Fluent Bit does not allow a file to be included twice in the same configuration"'
+        );
+        expect(error.formattedError).toMatchInlineSnapshot(
           '"<PROJECT_ROOT>/__fixtures__/directives/include/withDuplicatedIncludes.conf: 9:1 You are trying to include <PROJECT_ROOT>/__fixtures__/directives/include/nested/tail.conf. Fluent Bit does not allow a file to be included twice in the same configuration"'
         );
         expect(error.filePath).toMatchInlineSnapshot(
@@ -154,6 +163,9 @@ describe('Fluent Bit: Directives', () => {
         expect(error.line).toBe(3);
         expect(error.col).toBe(1);
         expect(error.message).toMatchInlineSnapshot(
+          '"Can not read file, loading from <PROJECT_ROOT>/__fixtures__/directives/include/withFailingIncludes.conf "'
+        );
+        expect(error.formattedError).toMatchInlineSnapshot(
           '"<PROJECT_ROOT>/__fixtures__/directives/include/nested/notExistentInclude.conf: 3:1 Can not read file, loading from <PROJECT_ROOT>/__fixtures__/directives/include/withFailingIncludes.conf "'
         );
         expect(error.filePath).toMatchInlineSnapshot(

--- a/__tests__/fluentBit.spec.ts
+++ b/__tests__/fluentBit.spec.ts
@@ -1,5 +1,6 @@
 import { readFileSync } from 'fs';
 import { FluentBitSchema } from '../index';
+import type { TokenError } from '../src';
 import { cases } from '../__fixtures__/fluentBitCases';
 
 jest.mock('uuid', () => ({ v4: () => 'UNIQUE' }));
@@ -52,14 +53,28 @@ describe('Fluent Bit', () => {
     `);
     });
     it('Fails if config has no fields', () => {
-      expect(() => new FluentBitSchema('# some comment', '/file/path.conf')).toThrowErrorMatchingInlineSnapshot(
-        '"/file/path.conf: 0:0 This file is not a valid Fluent Bit config file"'
-      );
+      try {
+        new FluentBitSchema('# some comment', '/file/path.conf');
+      } catch (e) {
+        const error = e as TokenError;
+        expect(error.message).toMatchInlineSnapshot('"This file is not a valid Fluent Bit config file"');
+        expect(error.formattedError).toMatchInlineSnapshot(
+          '"/file/path.conf: 0:0 This file is not a valid Fluent Bit config file"'
+        );
+      }
+
+      expect.hasAssertions();
     });
     it('Fails if config is empty', () => {
-      expect(() => new FluentBitSchema('       ', '/file/path.conf')).toThrowErrorMatchingInlineSnapshot(
-        '"/file/path.conf: 0:0 File is empty"'
-      );
+      try {
+        new FluentBitSchema('       ', '/file/path.conf');
+      } catch (e) {
+        const error = e as TokenError;
+        expect(error.message).toMatchInlineSnapshot('"File is empty"');
+        expect(error.formattedError).toMatchInlineSnapshot('"/file/path.conf: 0:0 File is empty"');
+      }
+
+      expect.hasAssertions();
     });
 
     it('Should transform schema to string for basic.conf', () => {

--- a/src/TokenError.ts
+++ b/src/TokenError.ts
@@ -1,5 +1,3 @@
-const formatError = (message: string, filePath: string, line: number, col: number): string =>
-  `${filePath}: ${line}:${col} ${message}`;
 export class TokenError extends Error {
   line: number;
   col: number;
@@ -7,12 +5,15 @@ export class TokenError extends Error {
 
   filePath: string;
   constructor(message: string, filePath: string, line: number, col: number) {
-    const errorMsg = formatError(message, filePath, line, col);
-    super(errorMsg);
+    super(message);
     this.name = 'TokenError';
-    this.message = formatError(message, filePath, line, col);
+    this.message = message;
     this.filePath = filePath;
     this.line = line;
     this.col = col;
+  }
+
+  get formattedError() {
+    return `${this.filePath}: ${this.line}:${this.col} ${this.message}`;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,2 +1,3 @@
 export * from './parser';
 export * from './schemaToString';
+export * from './TokenError';


### PR DESCRIPTION
This PR exposes TokenError class. this is useful to guard generic errors against TokenError. 

I've also added a new method that exposes the `formattedError` and leaves the Error without extra format. 