### PR TITLE
we should export the TokenError class as a First Citizen

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,1 +1,1 @@
-export { FluentBitSchema } from './src';
+export { FluentBitSchema, TokenError } from './src';


### PR DESCRIPTION
TokenError should be exposed at the top-level index. 