### PR TITLE
Guarding directives recognition

### DIFF
--- a/__fixtures__/directives/set/withManySets.conf
+++ b/__fixtures__/directives/set/withManySets.conf
@@ -1,0 +1,24 @@
+# This value is ignored as there is a later set.
+@set A=B
+
+# Brace handling is buggy so ${A} expands to 2 in the dummy input.
+@set ${A}=1
+@set ${A=2
+
+# Note the space which becomes part of the variable name, we should not do this.
+@set C =3
+
+[INPUT]
+  name dummy
+  dummy { "C space":"${C }", "A":"${A}", "$A": "${${A}}", "C": "${C}", "C space":"${C }" }
+
+# We set A again which means the previous set is ignored
+@set A=Z
+
+[INPUT]
+  name dummy
+  dummy { "A":"${A}" }
+
+[OUTPUT]
+  name stdout
+  match *

--- a/__tests__/directives.spec.ts
+++ b/__tests__/directives.spec.ts
@@ -258,6 +258,35 @@ describe('Fluent Bit: Directives', () => {
     it('Should fail when @SET directive is malformed', () => {
       const filePath = '/__fixtures__/directives/set/ephemeral.conf';
       const rawConfig = `
+      # Note the space which becomes part of the variable name, we should not do this. but is allowed :/
+      @set C =3
+      
+      [INPUT]
+        name dummy
+        dummy {"message":"\${C }"}
+      
+      `;
+      const config = new FluentBitSchema(rawConfig, filePath);
+
+      expect(config.directives).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "col": 7,
+            "filePath": "/__fixtures__/directives/set/ephemeral.conf",
+            "line": 3,
+            "lineBreaks": 0,
+            "offset": 112,
+            "text": "@set C =3",
+            "toString": [Function],
+            "type": "SET",
+            "value": "@SET C =3",
+          },
+        ]
+      `);
+    });
+    it('Should parse correctly the @SET directive', () => {
+      const filePath = '/__fixtures__/directives/set/ephemeral.conf';
+      const rawConfig = `
       @SET A = some configuration here again =
       @set C=some configuration here
       
@@ -267,17 +296,34 @@ describe('Fluent Bit: Directives', () => {
       
       `;
 
-      try {
-        new FluentBitSchema(rawConfig, filePath);
-      } catch (e) {
-        const error = e as TokenError;
-        expect(error.message).toMatchInlineSnapshot(`
-          "invalid syntax at line 2 col 7:
+      const config = new FluentBitSchema(rawConfig, filePath);
 
-                  @SET A = some configuration here again =
-                  ^"
-        `);
-      }
+      expect(config.directives).toMatchInlineSnapshot(`
+        Array [
+          Object {
+            "col": 7,
+            "filePath": "/__fixtures__/directives/set/ephemeral.conf",
+            "line": 2,
+            "lineBreaks": 0,
+            "offset": 7,
+            "text": "@SET A = some configuration here again =",
+            "toString": [Function],
+            "type": "SET",
+            "value": "@SET A = some configuration here again =",
+          },
+          Object {
+            "col": 7,
+            "filePath": "/__fixtures__/directives/set/ephemeral.conf",
+            "line": 3,
+            "lineBreaks": 0,
+            "offset": 54,
+            "text": "@set C=some configuration here",
+            "toString": [Function],
+            "type": "SET",
+            "value": "@SET C=some configuration here",
+          },
+        ]
+      `);
     });
 
     it('Should add the @SET directive when calling toString()', () => {
@@ -322,6 +368,7 @@ describe('Fluent Bit: Directives', () => {
         );
         expect(error.filePath).toMatchInlineSnapshot('"<PROJECT_ROOT>/__fixtures__/directives/set/withManySets.conf"');
       }
+      expect.hasAssertions();
     });
   });
 });

--- a/__tests__/directives.spec.ts
+++ b/__tests__/directives.spec.ts
@@ -258,7 +258,7 @@ describe('Fluent Bit: Directives', () => {
       const config = new FluentBitSchema(rawConfig, filePath);
       expect(config.directives).toMatchSnapshot();
     });
-    it('Should fail when @SET directive is malformed', () => {
+    it('Should parse the @SET directive correctly', () => {
       const filePath = '/__fixtures__/directives/set/ephemeral.conf';
       const rawConfig = `
       # Note the space which becomes part of the variable name, we should not do this. but is allowed :/

--- a/__tests__/directives.spec.ts
+++ b/__tests__/directives.spec.ts
@@ -21,10 +21,10 @@ describe('Fluent Bit: Directives', () => {
     } catch (e) {
       const error = e as TokenError;
       expect(error.message).toMatchInlineSnapshot(
-        '"You have defined a Directive not supported (@WHATEVER something that we do not have implemented/invalid. ). The supported directives are: SET,INCLUDE"'
+        '"You have defined a directive that cannot be parse (@WHATEVER something that we do not have implemented/invalid. ). The supported directives are: SET,INCLUDE"'
       );
       expect(error.formattedError).toMatchInlineSnapshot(
-        '"/__fixtures__/directives/directives/ephemeral.conf: 3:5 You have defined a Directive not supported (@WHATEVER something that we do not have implemented/invalid. ). The supported directives are: SET,INCLUDE"'
+        '"/__fixtures__/directives/directives/ephemeral.conf: 3:5 You have defined a directive that cannot be parse (@WHATEVER something that we do not have implemented/invalid. ). The supported directives are: SET,INCLUDE"'
       );
     }
     expect.hasAssertions();
@@ -255,7 +255,7 @@ describe('Fluent Bit: Directives', () => {
       const config = new FluentBitSchema(rawConfig, filePath);
       expect(config.directives).toMatchSnapshot();
     });
-    it('Should fail when @SET directive  is malformed', () => {
+    it('Should fail when @SET directive is malformed', () => {
       const filePath = '/__fixtures__/directives/set/ephemeral.conf';
       const rawConfig = `
       @SET A = some configuration here again =
@@ -303,6 +303,25 @@ describe('Fluent Bit: Directives', () => {
           dummy {\\"message\\":\\"\${A}\\"} 
         "
       `);
+    });
+    it('Should fail when @SET directive is malformed', async () => {
+      const filePath = './__fixtures__/directives/set/withManySets.conf';
+      const rawConfig = readFileSync(filePath, { encoding: 'utf-8' });
+      try {
+        new FluentBitSchema(rawConfig, filePath);
+      } catch (e) {
+        expect(e).toBeInstanceOf(TokenError);
+        const error = e as TokenError;
+        expect(error.line).toBe(5);
+        expect(error.col).toBe(1);
+        expect(error.message).toMatchInlineSnapshot(
+          '"You have defined a directive that cannot be parse (@set ${A}=1). The supported directives are: SET,INCLUDE"'
+        );
+        expect(error.formattedError).toMatchInlineSnapshot(
+          '"<PROJECT_ROOT>/__fixtures__/directives/set/withManySets.conf: 5:1 You have defined a directive that cannot be parse (@set ${A}=1). The supported directives are: SET,INCLUDE"'
+        );
+        expect(error.filePath).toMatchInlineSnapshot('"<PROJECT_ROOT>/__fixtures__/directives/set/withManySets.conf"');
+      }
     });
   });
 });

--- a/__tests__/directives.spec.ts
+++ b/__tests__/directives.spec.ts
@@ -130,6 +130,7 @@ describe('Fluent Bit: Directives', () => {
           '"<PROJECT_ROOT>/__fixtures__/directives/include/withWrongIncludeValue.conf"'
         );
       }
+      expect.hasAssertions();
     });
     it('Fails retrieving a repeated @INCLUDE (can not include file twice) ', async () => {
       const filePath = '__fixtures__/directives/include/withDuplicatedIncludes.conf';
@@ -151,6 +152,7 @@ describe('Fluent Bit: Directives', () => {
           '"<PROJECT_ROOT>/__fixtures__/directives/include/withDuplicatedIncludes.conf"'
         );
       }
+      expect.hasAssertions();
     });
     it('Fails retrieving a missing @include (file not found) ', async () => {
       const filePath = './__fixtures__/directives/include/withFailingIncludes.conf';
@@ -172,6 +174,7 @@ describe('Fluent Bit: Directives', () => {
           '"<PROJECT_ROOT>/__fixtures__/directives/include/nested/notExistentInclude.conf"'
         );
       }
+      expect.hasAssertions();
     });
   });
   describe('@SET', () => {

--- a/__tests__/fluentBit.spec.ts
+++ b/__tests__/fluentBit.spec.ts
@@ -62,7 +62,6 @@ describe('Fluent Bit', () => {
           '"/file/path.conf: 0:0 This file is not a valid Fluent Bit config file"'
         );
       }
-
       expect.hasAssertions();
     });
     it('Fails if config is empty', () => {
@@ -73,7 +72,6 @@ describe('Fluent Bit', () => {
         expect(error.message).toMatchInlineSnapshot('"File is empty"');
         expect(error.formattedError).toMatchInlineSnapshot('"/file/path.conf: 0:0 File is empty"');
       }
-
       expect.hasAssertions();
     });
 

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -25,8 +25,11 @@ const caseInsensitiveKeywords = (defs: Record<string, string>) => {
   const keys = keywords(defs);
   return (value: string) => {
     const matches = value.match(/@(\w+)\s+\w+/) || [];
-    const lala = keys(matches[1].toUpperCase());
-    return lala;
+    try {
+      return keys(matches[1].toUpperCase());
+    } catch (e) {
+      return keys('');
+    }
   };
 };
 
@@ -85,7 +88,7 @@ export function tokenize(
   for (const token of lexer) {
     if (token.type === TOKEN_TYPES.DIRECTIVES) {
       throw new TokenError(
-        `You have defined a Directive not supported (${token.text}). The supported directives are: ${Object.keys(
+        `You have defined a directive that cannot be parse (${token.text}). The supported directives are: ${Object.keys(
           TOKEN_TYPES_DIRECTIVES
         )}`,
         filePath,


### PR DESCRIPTION
It could be that a @set is declared in such a way that the parser can not tokenize the line. This is particularly sensitive when the `@SET` directive is written with special characters, like `@set ${A}=1` 


we will fail the parsing when this occurs. 