### PR TITLE
fixing @INCLUDE error

### DIFF
--- a/__tests__/directives.spec.ts
+++ b/__tests__/directives.spec.ts
@@ -121,10 +121,10 @@ describe('Fluent Bit: Directives', () => {
         expect(error.line).toBe(3);
         expect(error.col).toBe(1);
         expect(error.message).toMatchInlineSnapshot(
-          '"You are trying to include nested/tail.conf, but we also found more arguments (shouldNotHaveAnytingElse). Includes can only have a single value (ex: @includes path/to/a/file)"'
+          '"You are trying to include nested/tail.conf, but we also found more arguments (shouldNotHaveAnytingElse). @INCLUDE directive can only have a single value (ex: @INCLUDE path/to/a/file)"'
         );
         expect(error.formattedError).toMatchInlineSnapshot(
-          '"<PROJECT_ROOT>/__fixtures__/directives/include/withWrongIncludeValue.conf: 3:1 You are trying to include nested/tail.conf, but we also found more arguments (shouldNotHaveAnytingElse). Includes can only have a single value (ex: @includes path/to/a/file)"'
+          '"<PROJECT_ROOT>/__fixtures__/directives/include/withWrongIncludeValue.conf: 3:1 You are trying to include nested/tail.conf, but we also found more arguments (shouldNotHaveAnytingElse). @INCLUDE directive can only have a single value (ex: @INCLUDE path/to/a/file)"'
         );
         expect(error.filePath).toMatchInlineSnapshot(
           '"<PROJECT_ROOT>/__fixtures__/directives/include/withWrongIncludeValue.conf"'
@@ -164,14 +164,12 @@ describe('Fluent Bit: Directives', () => {
         const error = e as TokenError;
         expect(error.line).toBe(3);
         expect(error.col).toBe(1);
-        expect(error.message).toMatchInlineSnapshot(
-          '"Can not read file, loading from <PROJECT_ROOT>/__fixtures__/directives/include/withFailingIncludes.conf "'
-        );
+        expect(error.message).toMatchInlineSnapshot('"Can not read file nested/notExistentInclude.conf"');
         expect(error.formattedError).toMatchInlineSnapshot(
-          '"<PROJECT_ROOT>/__fixtures__/directives/include/nested/notExistentInclude.conf: 3:1 Can not read file, loading from <PROJECT_ROOT>/__fixtures__/directives/include/withFailingIncludes.conf "'
+          '"<PROJECT_ROOT>/__fixtures__/directives/include/withFailingIncludes.conf: 3:1 Can not read file nested/notExistentInclude.conf"'
         );
         expect(error.filePath).toMatchInlineSnapshot(
-          '"<PROJECT_ROOT>/__fixtures__/directives/include/nested/notExistentInclude.conf"'
+          '"<PROJECT_ROOT>/__fixtures__/directives/include/withFailingIncludes.conf"'
         );
       }
       expect.hasAssertions();

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -106,7 +106,7 @@ export function tokenize(
       // In case we find more arguments in the value given to the include directive we will fail with some guidance in the error.
       if (rest.length) {
         throw new TokenError(
-          `You are trying to include ${includeFilePath}, but we also found more arguments (${rest}). Includes can only have a single value (ex: @includes path/to/a/file)`,
+          `You are trying to include ${includeFilePath}, but we also found more arguments (${rest}). @INCLUDE directive can only have a single value (ex: @INCLUDE path/to/a/file)`,
           filePath,
           token.line,
           token.col
@@ -133,7 +133,7 @@ export function tokenize(
         if (e instanceof TokenError) {
           throw e;
         }
-        throw new TokenError(`Can not read file, loading from ${filePath} `, fullPath, token.line, token.col);
+        throw new TokenError(`Can not read file ${includeFilePath}`, filePath, token.line, token.col);
       }
 
       directives.push({ ...token, filePath: fullPath });


### PR DESCRIPTION
The TokenError for an include that couldn't be found was being reported with the wrong filePath. The filePath should be the source of the include, in other words, the file that is including the non-existent file. 

