### PR TITLE
changing types to simplify use

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm install
       - run: npm run build
+      - run: npm run build-types
       - run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -33,8 +33,8 @@ export enum TOKEN_TYPES {
 export type FluentBitSection = {
   id: string;
   name?: string;
-  command: COMMANDS;
-  optional?: { [key: string]: unknown };
+  command: keyof typeof COMMANDS;
+  optional?: Record<string, string>;
 };
 
 export interface FluentBitSchemaType extends FluentBitSection {


### PR DESCRIPTION
Currently, the types are too narrow and require guards to avoid casting. 

this, altho save, makes using the library a bit rigid. changing some types to relax the schema type. 

I've also corrected the type headers so now are produced when releasing.  